### PR TITLE
feat: F-009 Kategorie-Eingabe in der Artikel-UX [v0.9.4+49]

### DIFF
--- a/app/lib/config/app_config.dart
+++ b/app/lib/config/app_config.dart
@@ -315,6 +315,7 @@ static const int inputMaxLengthOrt = 60;
 static const int inputMaxLengthFach = 60;
 static const int inputMaxMenge = 999999;
 static const int inputMinArtikelnummer = 1000;
+static const int inputMaxLengthKategorie = 50;
 
 
 // ── Kamera / Bildverarbeitung ─────────────────────────────────────

--- a/app/lib/screens/artikel_detail_screen.dart
+++ b/app/lib/screens/artikel_detail_screen.dart
@@ -59,6 +59,7 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
   late final TextEditingController _beschreibungController;
   late final TextEditingController _ortController;
   late final TextEditingController _fachController;
+  late final TextEditingController _kategorieController;
   late int _menge;
   bool _isEditing = false;
   bool _hasChanged = false;
@@ -103,6 +104,8 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
     _ortController = TextEditingController(text: widget.artikel.ort)
       ..addListener(_onChanged);
     _fachController = TextEditingController(text: widget.artikel.fach)
+      ..addListener(_onChanged);
+    _kategorieController = TextEditingController(text: widget.artikel.kategorie ?? '',)
       ..addListener(_onChanged);
     _menge = widget.artikel.menge;
     _bildPfad =
@@ -404,6 +407,7 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
     _nameController.dispose();
     _beschreibungController.dispose();
     _ortController.dispose();
+    _kategorieController.dispose();
     _fachController.dispose();
     super.dispose();
   }
@@ -559,6 +563,9 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
         'ort': _ortController.text,
         'fach': _fachController.text,
         'beschreibung': _beschreibungController.text,
+        'kategorie': _kategorieController.text.trim().isEmpty
+            ? null
+            : _kategorieController.text.trim(),
         'aktualisiertAm': now.toIso8601String(),
         'updated_at': now.millisecondsSinceEpoch,
       };
@@ -621,6 +628,9 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
         ort: _ortController.text,
         fach: _fachController.text,
         beschreibung: _beschreibungController.text,
+        kategorie: _kategorieController.text.trim().isEmpty
+            ? null
+            : _kategorieController.text.trim(),
         aktualisiertAm: now,
         remoteBildPfad: neuerBildPfad,
         remotePath: recordId,
@@ -672,6 +682,9 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
       ort: _ortController.text,
       fach: _fachController.text,
       beschreibung: _beschreibungController.text,
+      kategorie: _kategorieController.text.trim().isEmpty
+          ? null
+          : _kategorieController.text.trim(),
       bildPfad: _bildPfad ?? '',  // M-013: null → leerer String
       aktualisiertAm: DateTime.now().toUtc(),
     );
@@ -1308,6 +1321,23 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
                         ),
                       ),
                     ),
+
+                  // ── Kategorie ──────────────────────────────────
+                  TextField(
+                    controller: _kategorieController,
+                    enabled: _isEditing && !isBlocked,
+                    textCapitalization: TextCapitalization.sentences,
+                    decoration: InputDecoration(
+                      labelText: 'Kategorie',
+                      border: const OutlineInputBorder(),
+                      prefixIcon: const Icon(Icons.category_outlined),
+                      filled: true,
+                      fillColor: _isEditing
+                          ? colorScheme.surface
+                          : colorScheme.surfaceContainerLow,
+                    ),
+                  ),
+                  const SizedBox(height: AppConfig.spacingSectionGap),
 
                   // M-011: Zentrales Bild-Widget mit Vollbild-Tap
                   if (_isLoadingRemoteBild)

--- a/app/lib/screens/artikel_erfassen_screen.dart
+++ b/app/lib/screens/artikel_erfassen_screen.dart
@@ -46,6 +46,7 @@ class _ArtikelErfassenScreenState extends State<ArtikelErfassenScreen> {
   final _fachCtrl = TextEditingController();
   final _mengeCtrl = TextEditingController(text: '0');
   final _artikelnummerCtrl = TextEditingController();
+  final _kategorieCtrl = TextEditingController();
 
   // v0.7.8 Punkt 4: FocusNode für Menge-Feld
   final FocusNode _mengeFocus = FocusNode();
@@ -77,6 +78,7 @@ class _ArtikelErfassenScreenState extends State<ArtikelErfassenScreen> {
     _fachCtrl.addListener(_markDirty);
     _mengeCtrl.addListener(_markDirty);
     _artikelnummerCtrl.addListener(_markDirty);
+    _kategorieCtrl.addListener(_markDirty);
 
     // v0.7.8 Punkt 4: Beim Fokus den gesamten Inhalt des Menge-Felds markieren
     _mengeFocus.addListener(() {
@@ -125,6 +127,7 @@ class _ArtikelErfassenScreenState extends State<ArtikelErfassenScreen> {
     _fachCtrl.dispose();
     _mengeCtrl.dispose();
     _artikelnummerCtrl.dispose();
+    _kategorieCtrl.dispose();
     // v0.7.8 Punkt 4: FocusNode disposen
     _mengeFocus.dispose();
     super.dispose();
@@ -419,6 +422,9 @@ class _ArtikelErfassenScreenState extends State<ArtikelErfassenScreen> {
         name: name,
         artikelnummer: artikelnummer,
         beschreibung: _beschreibungCtrl.text.trim(),
+        kategorie: _kategorieCtrl.text.trim().isEmpty
+            ? null
+            : _kategorieCtrl.text.trim(),
         ort: ort,
         fach: fach,
         menge: menge,
@@ -592,6 +598,20 @@ class _ArtikelErfassenScreenState extends State<ArtikelErfassenScreen> {
                   ),
                   maxLines: 2,
                   maxLength: AppConfig.inputMaxLengthBeschreibung,
+                ),
+                const SizedBox(height: AppConfig.spacingMedium),
+
+                // ── Kategorie ─────────────────────────────────
+                TextFormField(
+                  controller: _kategorieCtrl,
+                  textCapitalization: TextCapitalization.sentences,
+                  decoration: const InputDecoration(
+                    labelText: 'Kategorie',
+                    border: OutlineInputBorder(),
+                    prefixIcon: Icon(Icons.category_outlined),
+                  ),
+                  maxLength: AppConfig.inputMaxLengthKategorie,
+                  textInputAction: TextInputAction.next,
                 ),
                 const SizedBox(height: AppConfig.spacingMedium),
 

--- a/app/lib/screens/artikel_list_screen.dart
+++ b/app/lib/screens/artikel_list_screen.dart
@@ -3,7 +3,7 @@
 //   B-008 — _buildArtikelTile(): Card-Layout mit allen Feldern wiederhergestellt.
 //            Artikelnummer (nullable int), Beschreibung, Ort, Fach, Menge als Chips.
 //   B-009 — Ort-Dropdown aus AppBar entfernt, in Body mit echten Daten implementiert.
-//            _aktualisiereVerfuegbareOrte(): distinct, alphabetisch, aus _artikelListe.
+//            _aktualisiereFilter(): distinct, alphabetisch, aus _artikelListe.
 //   B-010 — _showSnackBar(): Zentrale Hilfsmethode. Feedback bei Sync-Start/-Erfolg/-Fehler.
 //   B-012 — Sync-Label: overflow + maxLines. titleSpacing + Padding gegen AppBar-Overflow.
 
@@ -59,6 +59,7 @@ class _ArtikelListScreenState extends State<ArtikelListScreen> {
   List<Artikel> _artikelListe = [];
   String _suchbegriff = '';
   String _filterOrt = '';
+  String _filterKategorie = '';
   bool _isLoading = true;
   bool? _pbConnected;
 
@@ -81,6 +82,7 @@ class _ArtikelListScreenState extends State<ArtikelListScreen> {
 
   // B-009: Verfügbare Orte für den Filter — dynamisch aus _artikelListe
   List<String> _verfuegbareOrte = [];
+  List<String> _verfuegbareKategorien = [];
 
   @override
   void initState() {
@@ -93,7 +95,7 @@ class _ArtikelListScreenState extends State<ArtikelListScreen> {
       _artikelListe = List<Artikel>.from(widget.initialArtikel!);
       _isLoading = false;
       // B-009: Orte aus initialArtikel ableiten
-      _aktualisiereVerfuegbareOrte();
+      _aktualisiereFilter();
     } else {
       _ladeArtikel();
     }
@@ -138,16 +140,25 @@ class _ArtikelListScreenState extends State<ArtikelListScreen> {
     super.dispose();
   }
 
-  // ── B-009: Orte aus der geladenen Liste ableiten ─────────────────────────
+  // ── B-009: Orte und Kategorien aus den geladenen Listen ableiten ─────────────────────────
   // Distinct, nicht-leere Werte, alphabetisch sortiert.
-  void _aktualisiereVerfuegbareOrte() {
+  void _aktualisiereFilter() {
     final orte = _artikelListe
         .map((a) => a.ort.trim())
         .where((o) => o.isNotEmpty)
         .toSet()
         .toList()
       ..sort();
-    setState(() => _verfuegbareOrte = orte);
+    final kategorien = _artikelListe
+        .map((a) => (a.kategorie ?? '').trim())
+        .where((k) => k.isNotEmpty)
+        .toSet()
+        .toList()
+      ..sort();
+    setState(() {
+      _verfuegbareOrte = orte;
+      _verfuegbareKategorien = kategorien;
+    });
   }
 
   // ── B-010: Zentrale Snackbar-Hilfsmethode ────────────────────────────────
@@ -190,7 +201,7 @@ class _ArtikelListScreenState extends State<ArtikelListScreen> {
         _hasMore = seite.length >= AppConfig.paginationPageSize;
       }
       // B-009: Orte nach jedem Laden aktualisieren
-      _aktualisiereVerfuegbareOrte();
+      _aktualisiereFilter();
     } catch (e) {
       _logger.e('Fehler beim Laden: $e');
       _showSnackBar('❌ Fehler beim Laden der Artikel', isError: true);
@@ -228,7 +239,7 @@ class _ArtikelListScreenState extends State<ArtikelListScreen> {
         _hasMore = seite.length >= AppConfig.paginationPageSize;
       });
       // B-009: Orte nach Nachladen aktualisieren
-      _aktualisiereVerfuegbareOrte();
+      _aktualisiereFilter();
     } finally {
       setState(() => _isLoadingMore = false);
     }
@@ -268,8 +279,16 @@ class _ArtikelListScreenState extends State<ArtikelListScreen> {
 
   List<Artikel> _gefilterteArtikel() {
     final basis = _suchbegriff.isNotEmpty ? _suchErgebnisse : _artikelListe;
-    if (_filterOrt.isEmpty) return basis;
-    return basis.where((a) => a.ort.trim() == _filterOrt.trim()).toList();
+    return basis.where((a) {
+      if (_filterOrt.isNotEmpty && a.ort.trim() != _filterOrt.trim()) {
+        return false;
+      }
+      if (_filterKategorie.isNotEmpty &&
+          (a.kategorie ?? '').trim() != _filterKategorie.trim()) {
+        return false;
+      }
+      return true;
+    }).toList();
   }
 
   String _formatTime(DateTime dt) {
@@ -405,7 +424,8 @@ class _ArtikelListScreenState extends State<ArtikelListScreen> {
           ),
 
           // ── B-009: Ort-Filter — im Body, mit echten Daten ───────────────
-          if (_verfuegbareOrte.isNotEmpty)
+          // ── F-009 / B-009: Ort- und Kategorie-Filter nebeneinander ────────
+          if (_verfuegbareOrte.isNotEmpty || _verfuegbareKategorien.isNotEmpty)
             Padding(
               padding: const EdgeInsets.fromLTRB(
                 AppConfig.spacingSmall,
@@ -414,45 +434,103 @@ class _ArtikelListScreenState extends State<ArtikelListScreen> {
                 0,
               ),
               child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  const Icon(Icons.place_outlined, size: 18),
-                  const SizedBox(width: AppConfig.spacingXSmall),
-                  Expanded(
-                    child: DropdownButton<String>(
-                      key: const Key('locationFilterDropdown'),
-                      value: _filterOrt.isEmpty ? null : _filterOrt,
-                      hint: const Text('Alle Orte'),
-                      isExpanded: true,
-                      underline: const SizedBox.shrink(),
-                      isDense: true,
-                      items: [
-                        // Erster Eintrag: "Alle Orte" → setzt Filter zurück
-                        const DropdownMenuItem<String>(
-                          value: null,
-                          child: Text('Alle Orte'),
-                        ),
-                        // Echte Orte aus der Artikelliste, alphabetisch
-                        ..._verfuegbareOrte.map(
-                          (ort) => DropdownMenuItem<String>(
-                            value: ort,
-                            child: Text(
-                              ort,
-                              overflow: TextOverflow.ellipsis,
+                  // ── Ort-Filter ──────────────────────────────────
+                  if (_verfuegbareOrte.isNotEmpty)
+                    Expanded(
+                      child: Row(
+                        children: [
+                          const Icon(Icons.place_outlined, size: 18),
+                          const SizedBox(width: AppConfig.spacingXSmall),
+                          Expanded(
+                            child: DropdownButton<String>(
+                              key: const Key('locationFilterDropdown'),
+                              value: _filterOrt.isEmpty ? null : _filterOrt,
+                              hint: const Text('Alle Orte'),
+                              isExpanded: true,
+                              underline: const SizedBox.shrink(),
+                              isDense: true,
+                              items: [
+                                const DropdownMenuItem<String>(
+                                  value: null,
+                                  child: Text('Alle Orte'),
+                                ),
+                                ..._verfuegbareOrte.map(
+                                  (ort) => DropdownMenuItem<String>(
+                                    value: ort,
+                                    child: Text(
+                                      ort,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                              onChanged: (v) => setState(() => _filterOrt = v ?? ''),
                             ),
                           ),
-                        ),
-                      ],
-                      onChanged: (String? newValue) {
-                        setState(() => _filterOrt = newValue ?? '');
-                      },
+                          if (_filterOrt.isNotEmpty)
+                            IconButton(
+                              icon: const Icon(Icons.clear, size: 18),
+                              tooltip: 'Ort-Filter zurücksetzen',
+                              visualDensity: VisualDensity.compact,
+                              onPressed: () => setState(() => _filterOrt = ''),
+                            ),
+                        ],
+                      ),
                     ),
-                  ),
-                  // Aktiver Filter → Reset-Button anzeigen
-                  if (_filterOrt.isNotEmpty)
-                    IconButton(
-                      icon: const Icon(Icons.clear, size: 18),
-                      tooltip: 'Filter zurücksetzen',
-                      onPressed: () => setState(() => _filterOrt = ''),
+
+                  // ── Abstand zwischen den Filtern ────────────────
+                  if (_verfuegbareOrte.isNotEmpty &&
+                      _verfuegbareKategorien.isNotEmpty)
+                    const SizedBox(width: AppConfig.spacingSmall),
+
+                  // ── Kategorie-Filter ────────────────────────────
+                  if (_verfuegbareKategorien.isNotEmpty)
+                    Expanded(
+                      child: Row(
+                        children: [
+                          const Icon(Icons.category_outlined, size: 18),
+                          const SizedBox(width: AppConfig.spacingXSmall),
+                          Expanded(
+                            child: DropdownButton<String>(
+                              key: const Key('categoryFilterDropdown'),
+                              value: _filterKategorie.isEmpty
+                                  ? null
+                                  : _filterKategorie,
+                              hint: const Text('Alle Kategorien'),
+                              isExpanded: true,
+                              underline: const SizedBox.shrink(),
+                              isDense: true,
+                              items: [
+                                const DropdownMenuItem<String>(
+                                  value: null,
+                                  child: Text('Alle Kategorien'),
+                                ),
+                                ..._verfuegbareKategorien.map(
+                                  (kat) => DropdownMenuItem<String>(
+                                    value: kat,
+                                    child: Text(
+                                      kat,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                              onChanged: (v) =>
+                                  setState(() => _filterKategorie = v ?? ''),
+                            ),
+                          ),
+                          if (_filterKategorie.isNotEmpty)
+                            IconButton(
+                              icon: const Icon(Icons.clear, size: 18),
+                              tooltip: 'Kategorie-Filter zurücksetzen',
+                              visualDensity: VisualDensity.compact,
+                              onPressed: () =>
+                                  setState(() => _filterKategorie = ''),
+                            ),
+                        ],
+                      ),
                     ),
                 ],
               ),
@@ -579,6 +657,13 @@ class _ArtikelListScreenState extends State<ArtikelListScreen> {
                           _buildInfoChip(
                             icon: Icons.place_outlined,
                             label: artikel.ort,
+                            colorScheme: colorScheme,
+                            textTheme: textTheme,
+                          ),
+                        if (artikel.kategorie != null && artikel.kategorie!.isNotEmpty)
+                          _buildInfoChip(
+                            icon: Icons.category_outlined,
+                            label: artikel.kategorie!,
                             colorScheme: colorScheme,
                             textTheme: textTheme,
                           ),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: Eine App zur Verwaltung von Elektronik- und Bastelartikeln
 
 publish_to: none
 
-version: 0.9.4+47
+version: 0.9.4+49
 
 environment:
   sdk: ">=3.3.0 <4.0.0"

--- a/docs/OPTIMIZATIONS.md
+++ b/docs/OPTIMIZATIONS.md
@@ -52,23 +52,6 @@ auch dann, wenn der Punkt später verschoben, umbenannt oder nach `Future` versc
 
 --- 
 
-## F-009 — Kategorie-Eingabe in der Artikel-UX
-
-**Priorität:** Niedrig
-**Branch:** fix/sync-hardening2-v0.9.4 (nach Merge: main)
-**Entdeckt bei:** B-001 / B-002
-
-### Problem
-Die technische Basis für `kategorie` ist inzwischen im Modell, Mapping, Persistenz- und Sync-Pfad vorhanden.  
-Offen ist — falls im aktuellen UI-Stand noch nicht umgesetzt — die vollständige und nutzerfreundliche Eingabe bzw. Bearbeitung in der Artikel-UX.
-
-### Gewünschtes Verhalten
-- Artikel-Formular enthält ein klar sichtbares Kategorie-Feld (Freitext oder Dropdown)
-- Wert lässt sich beim Erstellen und Bearbeiten eines Artikels setzen
-- Wert wird lokal persistiert und im Sync korrekt an PocketBase übertragen
-
-### Akzeptanzkriterium
-Die Kategorie ist im relevanten Artikel-UI-Flow vollständig nutzbar und die reale End-to-End-Übertragung ist bestätigt.
 
 --- 
 
@@ -152,8 +135,6 @@ Im Zweifel gilt der inhaltliche Status der einzelnen Punkte über den numerische
 **Aktuell besonders relevante offene Themen**
 - optionaler Realtest für den engeren technischen Duplicate-UUID-Recovery-Fallback
 - Android-Kamera-Verifikation
-- UI/UX für „Bild entfernen“
-- ggf. verbleibende UX-Ergänzung für `kategorie`
 - konfigurierbares Sync-Intervall
 
 ---
@@ -162,6 +143,29 @@ Im Zweifel gilt der inhaltliche Status der einzelnen Punkte über den numerische
 
 > **Hinweis:** Details zu den abgeschlossenen Punkten stehen in `HISTORY.md`.  
 > Hier bleiben sie als kompakter Überblick mit Versionsbezug erhalten.
+
+### F-009: Kategorie-Eingabe in der Artikel-UX — abgeschlossen 2026-05-04 | `0.9.4+49`
+
+**Priorität:** Niedrig
+**Branch:** fix/sync-hardening2-v0.9.4 (nach Merge: main)
+**Entdeckt bei:** B-001 / B-002
+
+### Problem
+Die technische Basis für `kategorie` ist inzwischen im Modell, Mapping, Persistenz- und Sync-Pfad vorhanden.  
+Offen ist — falls im aktuellen UI-Stand noch nicht umgesetzt — die vollständige und nutzerfreundliche Eingabe bzw. Bearbeitung in der Artikel-UX.
+
+### Gewünschtes Verhalten
+- Artikel-Formular enthält ein klar sichtbares Kategorie-Feld (Freitext oder Dropdown)
+- Wert lässt sich beim Erstellen und Bearbeiten eines Artikels setzen
+- Wert wird lokal persistiert und im Sync korrekt an PocketBase übertragen
+
+### Akzeptanzkriterium
+Die Kategorie ist im relevanten Artikel-UI-Flow vollständig nutzbar und die reale End-to-End-Übertragung ist bestätigt.
+
+### Ergebnis
+Kategorie-Feld (`String?`) in Erfassen- und Detail-Screen ergänzt (Freitext, `prefixIcon: category_outlined`, max 50 Zeichen). Listenansicht zeigt Kategorie als Chip. Kategorie-Filter als zweites Dropdown neben dem Ort-Filter (`Row` mit zwei `Expanded`, UND-verknüpft). Filter-Werte werden dynamisch aus der Artikelliste abgeleitet (`_aktualisiereFilter()`). `AppConfig.inputMaxLengthKategorie` ergänzt. Keine Änderungen an Modell, DB-Schema oder Sync nötig — technische Basis war bereits vorhanden. Verifiziert auf A515F + S20, PocketBase E2E bestätigt.
+
+--- 
 
 ### T-001: Konfliktlösung, Sync-Hardening und Integrationsverifikation (M-007) — abgeschlossen 2026-05-04 | `0.9.4+48`
 
@@ -592,6 +596,7 @@ Nach Sync-Erfolg/-Fehler fehlte Snackbar-Feedback (Regression aus B-007). Snackb
 
 | Datum | Version | Änderung |
 |---|---|---|
+| 2026-05-04 | 0.9.4+49 | F-009 umgesetzt: Kategorie-Feld in Erfassen/Detail/Liste, Kategorie-Filter neben Ort-Filter, Chip in Listenansicht. |
 | 2026-05-04 | 0.9.4+48 | T-001 abgeschlossen: Konfliktlösung, Sync-Hardening und Integrationsverifikation vollständig abgehakt. UUID-Pattern serverseitig abgesichert, UTC-Konsistenz geprüft (sauber), Zeitstempel-Semantik in DATABASE.md dokumentiert, verbleibende Optional-Punkte bewusst als „nicht benötigt" gestrichen. |
 | 2026-05-04 | 0.9.4+46 | M-013 abgeschlossen: Bild-Reset („Bild leeren") ermöglichen |
 | 2026-05-04 | 0.9.4+44 | O-012 abgeschlossen: Verbose-Flag geprüft und bewusst verworfen — Log-Level-Filter (F-006) deckt den Use Case ab. |


### PR DESCRIPTION
- Kategorie-Feld in ArtikelErfassenScreen und ArtikelDetailScreen
- Kategorie-Chip in ArtikelListScreen (_buildArtikelTile)
- Kategorie-Filter als Dropdown neben Ort-Filter (Row, Expanded)
- Filter UND-verknüpft, dynamisch aus Artikelliste abgeleitet
- AppConfig: inputMaxLengthKategorie (50)
- Keine Modell-/DB-/Sync-Änderungen nötig (Basis bereits vorhanden)
- Verifiziert auf A515F + S20, PocketBase E2E bestätigt

Refs #F-009